### PR TITLE
Fix user id parsing in services

### DIFF
--- a/HelloWorldWebApi/HelloWorldWebApi/Services/CharacterService.cs
+++ b/HelloWorldWebApi/HelloWorldWebApi/Services/CharacterService.cs
@@ -138,7 +138,11 @@ namespace HelloWorldWebApi.Services
             return serviceResponse;
         }
 
-        private int GetUserId() => int.Parse(_httpContextAccessor.HttpContext?.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty);
+        private int GetUserId()
+        {
+            var userIdString = _httpContextAccessor.HttpContext?.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            return int.TryParse(userIdString, out var userId) ? userId : 0;
+        }
         private string GetUserRole() => _httpContextAccessor.HttpContext?.User.FindFirstValue(ClaimTypes.Role) ?? string.Empty;
     }
 }

--- a/HelloWorldWebApi/HelloWorldWebApi/Services/CharacterSkillService.cs
+++ b/HelloWorldWebApi/HelloWorldWebApi/Services/CharacterSkillService.cs
@@ -33,8 +33,7 @@ namespace HelloWorldWebApi.Services
                     .Include(x => x.Weapon)
                     .Include(x => x.CharacterSkills)
                     .ThenInclude(x => x.Skill)
-                    .FirstOrDefaultAsync(x => x.Id == newCharacterSkill.CharacterId && x.User.Id ==
-                    int.Parse(_httpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)));
+                    .FirstOrDefaultAsync(x => x.Id == newCharacterSkill.CharacterId && x.User.Id == GetUserId());
 
                 if (character == null)
                 {
@@ -70,6 +69,12 @@ namespace HelloWorldWebApi.Services
             }
 
             return serviceResponse;
+        }
+
+        private int GetUserId()
+        {
+            var userIdString = _httpContextAccessor.HttpContext?.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            return int.TryParse(userIdString, out var userId) ? userId : 0;
         }
     }
 }

--- a/HelloWorldWebApi/HelloWorldWebApi/Services/WeaponService.cs
+++ b/HelloWorldWebApi/HelloWorldWebApi/Services/WeaponService.cs
@@ -29,7 +29,7 @@ namespace HelloWorldWebApi.Services
 
             try
             {
-                var character = await _dataContext.Characters.FirstOrDefaultAsync(x => x.Id == newWeapon.CharacterId && x.User.Id == int.Parse(_httpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier)));
+                var character = await _dataContext.Characters.FirstOrDefaultAsync(x => x.Id == newWeapon.CharacterId && x.User.Id == GetUserId());
 
                 if (character == null)
                 {
@@ -55,6 +55,12 @@ namespace HelloWorldWebApi.Services
             }
 
             return serviceResponse;
+        }
+
+        private int GetUserId()
+        {
+            var userIdString = _httpContextAccessor.HttpContext?.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            return int.TryParse(userIdString, out var userId) ? userId : 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- prevent FormatException in service methods if user id claim is missing
- add shared GetUserId helpers in various services

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6846581e71708327b25bbeec620e8a57