### PR TITLE
Add initial unit tests for web API services

### DIFF
--- a/HelloWorldWebApi/HelloWorldWebApi.Tests/CharacterServiceTests.cs
+++ b/HelloWorldWebApi/HelloWorldWebApi.Tests/CharacterServiceTests.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AutoMapper;
+using HelloWorldWebApi;
+using HelloWorldWebApi.Data;
+using HelloWorldWebApi.Dtos;
+using HelloWorldWebApi.Models;
+using HelloWorldWebApi.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace HelloWorldWebApi.Tests
+{
+    public class CharacterServiceTests
+    {
+        private static IMapper CreateMapper()
+        {
+            var config = new MapperConfiguration(cfg => { cfg.AddProfile<AutoMapperProfile>(); });
+            return config.CreateMapper();
+        }
+
+        private static IHttpContextAccessor CreateContextAccessor(int userId)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+                new Claim(ClaimTypes.Role, "Player")
+            }));
+
+            return new HttpContextAccessor { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task AddCharacter_AddsCharacterForCurrentUser()
+        {
+            var options = new DbContextOptionsBuilder<DataContext>()
+                .UseInMemoryDatabase("AddCharacterTest")
+                .Options;
+
+            using var context = new DataContext(options);
+            var user = new User { Id = 1, Username = "test", Role = "Player" };
+            context.Users.Add(user);
+            await context.SaveChangesAsync();
+
+            var service = new CharacterService(CreateMapper(), context, CreateContextAccessor(user.Id));
+
+            var newChar = new AddCharacterDto
+            {
+                Name = "Hero",
+                HitPoints = 100,
+                Strength = 10,
+                Defense = 10,
+                Intelligence = 10,
+                Class = CharacterClass.Knight
+            };
+
+            var response = await service.AddCharacter(newChar);
+
+            Assert.True(response.Success);
+            Assert.Single(context.Characters);
+            Assert.Equal("Hero", context.Characters.First().Name);
+        }
+    }
+}

--- a/HelloWorldWebApi/HelloWorldWebApi.Tests/HelloWorldWebApi.Tests.csproj
+++ b/HelloWorldWebApi/HelloWorldWebApi.Tests/HelloWorldWebApi.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HelloWorldWebApi\HelloWorldWebApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/HelloWorldWebApi/HelloWorldWebApi.Tests/WeaponServiceTests.cs
+++ b/HelloWorldWebApi/HelloWorldWebApi.Tests/WeaponServiceTests.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AutoMapper;
+using HelloWorldWebApi;
+using HelloWorldWebApi.Data;
+using HelloWorldWebApi.Dtos;
+using HelloWorldWebApi.Models;
+using HelloWorldWebApi.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace HelloWorldWebApi.Tests
+{
+    public class WeaponServiceTests
+    {
+        private static IMapper CreateMapper()
+        {
+            var config = new MapperConfiguration(cfg => { cfg.AddProfile<AutoMapperProfile>(); });
+            return config.CreateMapper();
+        }
+
+        private static IHttpContextAccessor CreateContextAccessor(int userId)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+                new Claim(ClaimTypes.Role, "Player")
+            }));
+
+            return new HttpContextAccessor { HttpContext = httpContext };
+        }
+
+        [Fact]
+        public async Task AddWeapon_AddsWeaponToCharacter()
+        {
+            var options = new DbContextOptionsBuilder<DataContext>()
+                .UseInMemoryDatabase("AddWeaponTest")
+                .Options;
+
+            using var context = new DataContext(options);
+            var user = new User { Id = 1, Username = "test", Role = "Player" };
+            var character = new Character { Id = 1, Name = "Hero", User = user };
+            context.Users.Add(user);
+            context.Characters.Add(character);
+            await context.SaveChangesAsync();
+
+            var service = new WeaponService(context, CreateContextAccessor(user.Id), CreateMapper());
+
+            var dto = new AddWeaponDto { CharacterId = character.Id, Name = "Sword", Damage = 20 };
+            var response = await service.AddWeapon(dto);
+
+            Assert.True(response.Success);
+            Assert.Single(context.Weapons);
+            Assert.Equal("Sword", context.Weapons.First().Name);
+            Assert.Equal("Sword", response.Data.Weapon.Name);
+        }
+    }
+}

--- a/HelloWorldWebApi/HelloWorldWebApi.sln
+++ b/HelloWorldWebApi/HelloWorldWebApi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.31313.79
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorldWebApi", "HelloWorldWebApi\HelloWorldWebApi.csproj", "{C86D288D-1B20-4106-AAAF-EA80EBAD5CBA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorldWebApi.Tests", "HelloWorldWebApi.Tests\HelloWorldWebApi.Tests.csproj", "{0BA984D5-42AC-4303-9398-8E95D9F792E8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +16,12 @@ Global
 		{C86D288D-1B20-4106-AAAF-EA80EBAD5CBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C86D288D-1B20-4106-AAAF-EA80EBAD5CBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C86D288D-1B20-4106-AAAF-EA80EBAD5CBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C86D288D-1B20-4106-AAAF-EA80EBAD5CBA}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {C86D288D-1B20-4106-AAAF-EA80EBAD5CBA}.Release|Any CPU.Build.0 = Release|Any CPU
+                {0BA984D5-42AC-4303-9398-8E95D9F792E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0BA984D5-42AC-4303-9398-8E95D9F792E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0BA984D5-42AC-4303-9398-8E95D9F792E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0BA984D5-42AC-4303-9398-8E95D9F792E8}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add new xUnit project `HelloWorldWebApi.Tests`
- cover `CharacterService.AddCharacter` and `WeaponService.AddWeapon` using EF InMemory
- include test project in `HelloWorldWebApi` solution

## Testing
- `dotnet test HelloWorldWebApi/HelloWorldWebApi.Tests/HelloWorldWebApi.Tests.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684659330e108327908b9e4329d340f7